### PR TITLE
Modified enrol and expel and added findc commands

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_CCA_DISPLAYED_INDEX = "The CCA index provided is invalid :(";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_CCAS_LISTED_OVERVIEW = "%1$d CCAs listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all persons and CCAs";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/cca/CcaDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaDeleteCommand.java
@@ -6,12 +6,12 @@ import java.util.List;
 import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.cca.Cca;
-import seedu.address.model.cca.Cid;
 
 public class CcaDeleteCommand extends Command {
     public static final String COMMAND_WORD = "deletec";
@@ -23,10 +23,10 @@ public class CcaDeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_CCA_SUCCESS = "Deleted CCA: %1$s";
 
-    private final Cid targetCid;
+    private final Index targetCcaIndex;
 
-    public CcaDeleteCommand(Cid targetCid) {
-        this.targetCid = targetCid;
+    public CcaDeleteCommand(Index targetCcaIndex) {
+        this.targetCcaIndex = targetCcaIndex;
     }
 
     @Override
@@ -34,13 +34,12 @@ public class CcaDeleteCommand extends Command {
         requireNonNull(model);
         List<Cca> lastShownList = model.getFilteredCcaList();
 
-        Optional<Cca> ccaToDelete = lastShownList.stream().filter(cca -> cca.cidEquals(targetCid)).findFirst();
-
-        if (!ccaToDelete.isPresent()) {
+        if (targetCcaIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CCA_DISPLAYED_INDEX);
         }
 
-        model.deleteCca(ccaToDelete.get());
+        Cca ccaToDelete = lastShownList.get(targetCcaIndex.getZeroBased());
+        model.deleteCca(ccaToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_CCA_SUCCESS, ccaToDelete));
     }
 
@@ -48,6 +47,6 @@ public class CcaDeleteCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof CcaDeleteCommand // instanceof handles nulls
-                && targetCid.equals(((CcaDeleteCommand) other).targetCid)); // state check
+                && targetCcaIndex.equals(((CcaDeleteCommand) other).targetCcaIndex)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/cca/CcaDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaDeleteCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.cca;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/logic/commands/cca/CcaEnrolCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaEnrolCommand.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
+import java.util.List;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -31,24 +34,34 @@ public class CcaEnrolCommand extends Command {
     public static final String MESSAGE_PRESENT_PERSON = "This person(%1$s) is already part of that CCA(%2$s)";
 
     private Cca ccaToEnrolInto;
-    private final int cid;
+    private final Index targetCcaIndex;
     private Person personToEnrol;
-    private final int pid;
+    private final Index targetPersonIndex;
 
     /**
      * Creates an CcaAddCommand to add the specified {@code Cca}
      */
-    public CcaEnrolCommand(Cid cid, Pid pid) {
-        this.cid = Integer.parseInt(cid.toString());
-        this.pid = Integer.parseInt(pid.toString());
+    public CcaEnrolCommand(Index targetCcaIndex, Index targetPersonIndex) {
+        this.targetCcaIndex = targetCcaIndex;
+        this.targetPersonIndex = targetPersonIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        this.ccaToEnrolInto = model.findCcaFromCid(cid);
-        this.personToEnrol = model.findPersonFromPid(pid);
+        List<Cca> lastShownCcaList = model.getFilteredCcaList();
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+
+        if (targetCcaIndex.getZeroBased() >= lastShownCcaList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CCA_DISPLAYED_INDEX);
+        }
+        if (targetPersonIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        this.ccaToEnrolInto = lastShownCcaList.get(targetCcaIndex.getZeroBased());
+        this.personToEnrol = lastShownPersonList.get(targetPersonIndex.getZeroBased());
 
         if (ccaToEnrolInto == null) {
             throw new CommandException(MESSAGE_MISSING_CCA);

--- a/src/main/java/seedu/address/logic/commands/cca/CcaEnrolCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaEnrolCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
 import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
@@ -12,9 +13,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.cca.Cca;
-import seedu.address.model.cca.Cid;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Pid;
 
 public class CcaEnrolCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/cca/CcaExpelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaExpelCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
 import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;

--- a/src/main/java/seedu/address/logic/commands/cca/CcaExpelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaExpelCommand.java
@@ -4,14 +4,15 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CCA_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
+import java.util.List;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.cca.Cca;
-import seedu.address.model.cca.Cid;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Pid;
 
 public class CcaExpelCommand extends Command {
     public static final String COMMAND_WORD = "expel";
@@ -29,27 +30,37 @@ public class CcaExpelCommand extends Command {
     public static final String MESSAGE_MISSING_PERSON = "This person does not exist in the address book";
     public static final String MESSAGE_MISSING_PERSON_FROM_CCA = "This person(%1$s) is not enrolled in this CCA(%2$s)";
 
-    private Cca ccaToEnrolInto;
-    private final int cid;
+    private Cca ccaToExpelFrom;
+    private final Index targetCcaIndex;
     private Person personToExpel;
-    private final int pid;
+    private final Index targetPersonIndex;
 
     /**
      * Creates an CcaAddCommand to add the specified {@code Cca}
      */
-    public CcaExpelCommand(Cid cid, Pid pid) {
-        this.cid = Integer.parseInt(cid.toString());
-        this.pid = Integer.parseInt(pid.toString());
+    public CcaExpelCommand(Index targetCcaIndex, Index targetPersonIndex) {
+        this.targetCcaIndex = targetCcaIndex;
+        this.targetPersonIndex = targetPersonIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        this.ccaToEnrolInto = model.findCcaFromCid(cid);
-        this.personToExpel = model.findPersonFromPid(pid);
+        List<Cca> lastShownCcaList = model.getFilteredCcaList();
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
 
-        if (ccaToEnrolInto == null) {
+        if (targetCcaIndex.getZeroBased() >= lastShownCcaList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CCA_DISPLAYED_INDEX);
+        }
+        if (targetPersonIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        this.ccaToExpelFrom = lastShownCcaList.get(targetCcaIndex.getZeroBased());
+        this.personToExpel = lastShownPersonList.get(targetPersonIndex.getZeroBased());
+
+        if (ccaToExpelFrom == null) {
             throw new CommandException(MESSAGE_MISSING_CCA);
         }
 
@@ -57,28 +68,20 @@ public class CcaExpelCommand extends Command {
             throw new CommandException(MESSAGE_MISSING_PERSON);
         }
 
-        boolean success = model.expelPersonFromCca(ccaToEnrolInto, personToExpel);
+        boolean success = model.expelPersonFromCca(ccaToExpelFrom, personToExpel);
         if (success) {
-            return new CommandResult(String.format(MESSAGE_SUCCESS, personToExpel.getName(), ccaToEnrolInto.getName()));
+            return new CommandResult(String.format(MESSAGE_SUCCESS, personToExpel.getName(), ccaToExpelFrom.getName()));
         } else {
             throw new CommandException(
-                    String.format(MESSAGE_MISSING_PERSON_FROM_CCA, personToExpel.getName(), ccaToEnrolInto.getName()));
+                    String.format(MESSAGE_MISSING_PERSON_FROM_CCA, personToExpel.getName(), ccaToExpelFrom.getName()));
         }
-    }
-
-    public Cca getCcaToEnrolInto() {
-        return this.ccaToEnrolInto;
-    }
-
-    public Person getPersonToExpel() {
-        return this.personToExpel;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof CcaExpelCommand // instanceof handles nulls
-                && ccaToEnrolInto.equals(((CcaExpelCommand) other).getCcaToEnrolInto())
-                && personToExpel.equals(((CcaExpelCommand) other).getPersonToExpel()));
+                && ccaToExpelFrom.equals(((CcaExpelCommand) other).ccaToExpelFrom)
+                && personToExpel.equals(((CcaExpelCommand) other).personToExpel));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/cca/CcaFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaFindCommand.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands.cca;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.cca.CcaNameContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class CcaFindCommand extends Command {
+
+    public static final String COMMAND_WORD = "findc";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all CCAs whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " string choir orchestra";
+
+    private final CcaNameContainsKeywordsPredicate predicate;
+
+    public CcaFindCommand(CcaNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredCcaList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_CCAS_LISTED_OVERVIEW, model.getFilteredCcaList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CcaFindCommand // instanceof handles nulls
+                && predicate.equals(((CcaFindCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/cca/CcaFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cca/CcaFindCommand.java
@@ -7,7 +7,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.cca.CcaNameContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.cca.CcaAddCommand;
 import seedu.address.logic.commands.cca.CcaDeleteCommand;
 import seedu.address.logic.commands.cca.CcaEnrolCommand;
 import seedu.address.logic.commands.cca.CcaExpelCommand;
+import seedu.address.logic.commands.cca.CcaFindCommand;
 import seedu.address.logic.commands.person.PersonAddCommand;
 import seedu.address.logic.commands.person.PersonDeleteCommand;
 import seedu.address.logic.commands.person.PersonEditCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.parser.cca.CcaAddCommandParser;
 import seedu.address.logic.parser.cca.CcaDeleteCommandParser;
 import seedu.address.logic.parser.cca.CcaEnrolCommandParser;
 import seedu.address.logic.parser.cca.CcaExpelCommandParser;
+import seedu.address.logic.parser.cca.CcaFindCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.person.PersonAddCommandParser;
 import seedu.address.logic.parser.person.PersonDeleteCommandParser;
@@ -74,6 +76,9 @@ public class AddressBookParser {
 
         case PersonFindCommand.COMMAND_WORD:
             return new PersonFindCommandParser().parse(arguments);
+
+        case CcaFindCommand.COMMAND_WORD:
+            return new CcaFindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -158,6 +158,7 @@ public class ParserUtil {
         return tagSet;
     }
 
+    // todo: Should be able to delete if the usual index works
     /**
      * Parses a {@code String cid} into an {@code int}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/cca/CcaDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaDeleteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser.cca;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.cca.CcaDeleteCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
@@ -19,8 +20,8 @@ public class CcaDeleteCommandParser implements Parser<CcaDeleteCommand> {
      */
     public CcaDeleteCommand parse(String args) throws ParseException {
         try {
-            Cid cid = ParserUtil.parseCid(args);
-            return new CcaDeleteCommand(cid);
+            Index index = ParserUtil.parseIndex(args);
+            return new CcaDeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CcaDeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/cca/CcaDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaDeleteCommandParser.java
@@ -7,7 +7,6 @@ import seedu.address.logic.commands.cca.CcaDeleteCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.cca.Cid;
 
 /**
  * Parses input arguments and creates a new CcaDeleteCommand object

--- a/src/main/java/seedu/address/logic/parser/cca/CcaEnrolCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaEnrolCommandParser.java
@@ -6,14 +6,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.cca.CcaEnrolCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.cca.Cid;
-import seedu.address.model.person.Pid;
 
 public class CcaEnrolCommandParser {
     /**
@@ -30,9 +29,9 @@ public class CcaEnrolCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CcaEnrolCommand.MESSAGE_USAGE));
         }
 
-        Cid cid = ParserUtil.parseCid(argMultimap.getValue(PREFIX_CCA_ID).get());
-        Pid pid = ParserUtil.parsePid(argMultimap.getValue(PREFIX_PERSON_ID).get());
-        return new CcaEnrolCommand(cid, pid);
+        Index ccaIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CCA_ID).get());
+        Index personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_ID).get());
+        return new CcaEnrolCommand(ccaIndex, personIndex);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/cca/CcaExpelCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaExpelCommandParser.java
@@ -6,14 +6,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_ID;
 
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.cca.CcaExpelCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.cca.Cid;
-import seedu.address.model.person.Pid;
 
 public class CcaExpelCommandParser {
     /**
@@ -30,9 +29,9 @@ public class CcaExpelCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CcaExpelCommand.MESSAGE_USAGE));
         }
 
-        Cid cid = ParserUtil.parseCid(argMultimap.getValue(PREFIX_CCA_ID).get());
-        Pid pid = ParserUtil.parsePid(argMultimap.getValue(PREFIX_PERSON_ID).get());
-        return new CcaExpelCommand(cid, pid);
+        Index ccaIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CCA_ID).get());
+        Index personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_ID).get());
+        return new CcaExpelCommand(ccaIndex, personIndex);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/cca/CcaFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaFindCommandParser.java
@@ -3,8 +3,8 @@ package seedu.address.logic.parser.cca;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+
 import seedu.address.logic.commands.cca.CcaFindCommand;
-import seedu.address.logic.commands.person.PersonFindCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.cca.CcaNameContainsKeywordsPredicate;

--- a/src/main/java/seedu/address/logic/parser/cca/CcaFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cca/CcaFindCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.cca;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import seedu.address.logic.commands.cca.CcaFindCommand;
+import seedu.address.logic.commands.person.PersonFindCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.cca.CcaNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new PersonFindCommand object
+ */
+public class CcaFindCommandParser implements Parser<CcaFindCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PersonFindCommand
+     * and returns a PersonFindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CcaFindCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CcaFindCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new CcaFindCommand(new CcaNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/cca/CcaNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/cca/CcaNameContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.cca;
+
+import java.util.List;
+import java.util.function.Predicate;
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code CcaName} matches any of the keywords given.
+ * To be used by findCcaCommand, but not implemented yet
+ */
+public class CcaNameContainsKeywordsPredicate implements Predicate<Cca> {
+    private final List<String> keywords;
+
+    public CcaNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Cca cca) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(cca.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CcaNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((CcaNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/cca/CcaNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/cca/CcaNameContainsKeywordsPredicate.java
@@ -2,8 +2,8 @@ package seedu.address.model.cca;
 
 import java.util.List;
 import java.util.function.Predicate;
+
 import seedu.address.commons.util.StringUtil;
-import seedu.address.model.person.Person;
 
 /**
  * Tests that a {@code Person}'s {@code CcaName} matches any of the keywords given.


### PR DESCRIPTION
Using Index.java instead of Pid and Cid allows for better integration of code, and less repeated code

Added findc command

When local storage is completed, delete all uses of cid and pid instances