### PR TITLE
Remove Gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,9 +26,6 @@ jobs:
         working-directory:  ${{ github.workspace }}/.github
         run: ./run-checks.sh
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
We're removing this test because:
1. It fails arbitrarily, with errors such as `Client disconnected` and `Client timeout`. This issue is [documented here](https://github.com/gradle/wrapper-validation-action/issues/40) and seems like it's due to a network issue. Flaky tests are bad.
2. The use-case of this test isn't applicable to us. The motive for it seems to be safeguarding against security issues when accepting a Gradle Wrapper binary from external contributors. We don't have external contributors as of now.